### PR TITLE
README: Add path to first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: php-actions/composer@v6 # or alternative dependency management
     - uses: php-actions/phpstan@v3
+      with:
+        path: src/
+
     # ... then your own project steps ...
 ```
 


### PR DESCRIPTION
Since `path`is a required argument, I feel like it should be included in the first example to make it self contained.