### PR TITLE
Made `path` input parameter are non-required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
 
   path:
     description: Path(s) with source code to run analysis on
-    required: true
+    required: false
 
   configuration:
     description: Configuration file location


### PR DESCRIPTION
This parameter is not necessary if the paths are already set in the configuration file.
Currently, we have to duplicate information from the configuration file into this parameter.